### PR TITLE
Tanny

### DIFF
--- a/Muse/Muse.xcodeproj/project.pbxproj
+++ b/Muse/Muse.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		445223642858360500F456CD /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 445223632858360500F456CD /* FirebaseStorage */; };
 		63B2EC6F2856BE5200E9E9CA /* TicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B2EC6E2856BE5200E9E9CA /* TicketView.swift */; };
 		63B2EC71285765D100E9E9CA /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B2EC70285765D100E9E9CA /* Animation.swift */; };
+		843766ED28587EE500339579 /* TicketMachineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843766EC28587EE500339579 /* TicketMachineView.swift */; };
 		84A776742852D809001FC86E /* MuseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A776732852D809001FC86E /* MuseApp.swift */; };
 		84A776762852D809001FC86E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A776752852D809001FC86E /* ContentView.swift */; };
 		84A776782852D80A001FC86E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84A776772852D80A001FC86E /* Assets.xcassets */; };
@@ -23,6 +24,7 @@
 		84A7769E2852EF75001FC86E /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A7769D2852EF75001FC86E /* MainView.swift */; };
 		84A776A02852FD70001FC86E /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A7769F2852FD70001FC86E /* MyPageView.swift */; };
 		84A776A2285301BF001FC86E /* MakeTicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A776A1285301BF001FC86E /* MakeTicketView.swift */; };
+		84DC485A2856DEB300EE8067 /* TicketListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DC48592856DEB300EE8067 /* TicketListView.swift */; };
 		A2AC011028582DC300130CB8 /* ResisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC010728582DC300130CB8 /* ResisterView.swift */; };
 		A2AC011128582DC300130CB8 /* RegistrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC010828582DC300130CB8 /* RegistrationViewModel.swift */; };
 		A2AC011228582DC300130CB8 /* RegistrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC010928582DC300130CB8 /* RegistrationService.swift */; };
@@ -33,7 +35,6 @@
 		A2AC011A28582DC900130CB8 /* AuthTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC011828582DC900130CB8 /* AuthTextField.swift */; };
 		A2AC011B28582DC900130CB8 /* AuthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC011928582DC900130CB8 /* AuthButton.swift */; };
 		A2AC011D28582E5300130CB8 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = A2AC011C28582E5300130CB8 /* GoogleService-Info.plist */; };
-		84DC485A2856DEB300EE8067 /* TicketListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DC48592856DEB300EE8067 /* TicketListView.swift */; };
 		DD983DAB285392FE00F8AD94 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD983DAA285392FE00F8AD94 /* Color.swift */; };
 /* End PBXBuildFile section */
 
@@ -57,6 +58,7 @@
 /* Begin PBXFileReference section */
 		63B2EC6E2856BE5200E9E9CA /* TicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketView.swift; sourceTree = "<group>"; };
 		63B2EC70285765D100E9E9CA /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
+		843766EC28587EE500339579 /* TicketMachineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketMachineView.swift; sourceTree = "<group>"; };
 		84A776702852D809001FC86E /* Muse.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Muse.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		84A776732852D809001FC86E /* MuseApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuseApp.swift; sourceTree = "<group>"; };
 		84A776752852D809001FC86E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 		84A7769D2852EF75001FC86E /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		84A7769F2852FD70001FC86E /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		84A776A1285301BF001FC86E /* MakeTicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeTicketView.swift; sourceTree = "<group>"; };
+		84DC48592856DEB300EE8067 /* TicketListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketListView.swift; sourceTree = "<group>"; };
 		A2AC010728582DC300130CB8 /* ResisterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResisterView.swift; sourceTree = "<group>"; };
 		A2AC010828582DC300130CB8 /* RegistrationViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationViewModel.swift; sourceTree = "<group>"; };
 		A2AC010928582DC300130CB8 /* RegistrationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationService.swift; sourceTree = "<group>"; };
@@ -80,7 +83,6 @@
 		A2AC011828582DC900130CB8 /* AuthTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthTextField.swift; sourceTree = "<group>"; };
 		A2AC011928582DC900130CB8 /* AuthButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthButton.swift; sourceTree = "<group>"; };
 		A2AC011C28582E5300130CB8 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		84DC48592856DEB300EE8067 /* TicketListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketListView.swift; sourceTree = "<group>"; };
 		DD983DAA285392FE00F8AD94 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -180,6 +182,7 @@
 			isa = PBXGroup;
 			children = (
 				84A7769D2852EF75001FC86E /* MainView.swift */,
+				843766EC28587EE500339579 /* TicketMachineView.swift */,
 				63B2EC6E2856BE5200E9E9CA /* TicketView.swift */,
 				63B2EC70285765D100E9E9CA /* Animation.swift */,
 			);
@@ -396,6 +399,7 @@
 				63B2EC71285765D100E9E9CA /* Animation.swift in Sources */,
 				84A7769E2852EF75001FC86E /* MainView.swift in Sources */,
 				84A776742852D809001FC86E /* MuseApp.swift in Sources */,
+				843766ED28587EE500339579 /* TicketMachineView.swift in Sources */,
 				A2AC011228582DC300130CB8 /* RegistrationService.swift in Sources */,
 				A2AC011028582DC300130CB8 /* ResisterView.swift in Sources */,
 				A2AC011128582DC300130CB8 /* RegistrationViewModel.swift in Sources */,

--- a/Muse/Muse/Auth/Login/LoginView.swift
+++ b/Muse/Muse/Auth/Login/LoginView.swift
@@ -17,50 +17,51 @@ struct LoginView: View {
         )
     
     var body: some View {
-        
-        VStack(spacing: 16) {
-            
-            AuthTextField(text: $viewModel.credentials.email,
-                          placeholder: "Email",
-                          keyboardType: .emailAddress,
-                          sfSymbol: "envelope")
-            
-            PwdTextFeild(password: $viewModel.credentials.password,
-                          placeholder: "Password",
-                         sfSymbol: "lock")
-            
-            AuthButton(title: "Login",
-                       background: .clear,
-                       foreground: .blue,
-                       border: .blue) {
-                viewModel.login()
+        NavigationView {
+            VStack(spacing: 16) {
+                
+                AuthTextField(text: $viewModel.credentials.email,
+                              placeholder: "Email",
+                              keyboardType: .emailAddress,
+                              sfSymbol: "envelope")
+                
+                PwdTextFeild(password: $viewModel.credentials.password,
+                              placeholder: "Password",
+                             sfSymbol: "lock")
+                
+                AuthButton(title: "Login",
+                           background: .clear,
+                           foreground: .blue,
+                           border: .blue) {
+                    viewModel.login()
+                }
+                
+                AuthButton(title: "Register",
+                           background: .clear,
+                           foreground: .blue,
+                           border: .blue) {
+                    showRegistration.toggle()
+                }
+                .sheet(isPresented: $showRegistration) {
+                    RegisterView()
+                }
             }
-            
-            AuthButton(title: "Register",
-                       background: .clear,
-                       foreground: .blue,
-                       border: .blue) {
-                showRegistration.toggle()
-            }
-            .sheet(isPresented: $showRegistration) {
-                RegisterView() 
-            }
-        }
-        .padding(.horizontal, 15)
-        .navigationTitle("Login")
-//        .alert(isPresented: $viewModel.hasError,
-//               content: {
+            .padding(.horizontal, 15)
+            .navigationTitle("Login")
+//            .alert(isPresented: $viewModel.hasError,
+//                   content: {
 //
-//            if case .failed(let error) = viewModel.state {
-//                return Alert(
-//                    title: Text("Error"),
-//                    message: Text(error.localizedDescription))
-//            } else {
-//                return Alert(
-//                    title: Text("Error"),
-//                    message: Text("Something went wrong"))
-//            }
-//        })
+//                if case .failed(let error) = viewModel.state {
+//                    return Alert(
+//                        title: Text("Error"),
+//                        message: Text(error.localizedDescription))
+//                } else {
+//                    return Alert(
+//                        title: Text("Error"),
+//                        message: Text("Something went wrong"))
+//                }
+//            })
+        }
     }
 }
 

--- a/Muse/Muse/ContentView.swift
+++ b/Muse/Muse/ContentView.swift
@@ -11,14 +11,19 @@ import Firebase
 struct ContentView: View {
     var body: some View {
         TabView {
-            MainView()
-                .tabItem {
-                    Label("홈", systemImage: "house")
-                }
-            MyPageView()
-                .tabItem {
-                    Label("내 라이브러리", systemImage: "square.grid.2x2.fill")
-                }
+            NavigationView {
+                MainView()
+            }
+            .tabItem {
+                Label("홈", systemImage: "house")
+            }
+            
+            NavigationView {
+                MyPageView()
+            }
+            .tabItem {
+                Label("내 라이브러리", systemImage: "square.grid.2x2.fill")
+            }
         }
         .accentColor(.customPink)
         .onAppear {

--- a/Muse/Muse/Main/MainView.swift
+++ b/Muse/Muse/Main/MainView.swift
@@ -13,75 +13,50 @@ struct MainView: View {
     
     var body: some View {
         ZStack {
-            Color.bgGrey.ignoresSafeArea()
+            Color.bgGrey.edgesIgnoringSafeArea(.all)
             VStack (spacing: 0){
                 Text("Muse Ticket")
-                    .font(.custom("Courier New", size: 34, relativeTo: .title))
-//relativeTo : 모든 기기마다 title이 갖는 값을 기준으로 34를 변환 시킨다.
-                    .padding(.bottom)
-                ZStack {
-                    Image("machine")
-                    //Image("ticket")
-                    VStack(spacing:40){
-                        Text("뮤즈풀한 음악을 위해 \n티켓을 뽑아보세요.")
-                            .font(.custom("Apple SD Gothic Neo Bold",size:20,relativeTo: .title))
-                            .foregroundColor(Color(red: 142/255, green: 142/255, blue: 147/255))
-                        //RGB를 할때는 255로 나눠야 합니다!!
-                            .multilineTextAlignment(.center)
-                        //                Text(markdownText)
-                        Text(
-                        """
-                        '\(Text("새 티켓뽑기").underline())'를 터치해
-                        랜덤으로 음악 티켓을 받을 수 있어요.
-                        
-                        '\(Text("티켓저장").underline())'을 터치해
-                        마음에 드는 음악과 코멘트를 모아보세요.
-                        
-                        '\(Text("내 라이브러리").underline())'에서
-                        나의 음악티켓을 작성할 수 있어요.
-                        """)
-                        .font(.custom("Apple SD Gothic Neo Heavy", size: 16, relativeTo: .title))
-                        .foregroundColor(Color(red: 142/255, green: 142/255, blue: 147/255))
-                        .multilineTextAlignment(.center)
-                        
-                    }
-                }
+                    .font(.custom("Courier New", size: 34, relativeTo: .title)) //relativeTo : 모든 기기마다 title이 갖는 값을 기준으로 34를 변환 시킨다.
+                    .padding()
+                
+                TicketMachineView()
     
                 HStack(alignment: .center, spacing: 20) {
                     Button(action: {
-                        print("이동 할꺼랍쇼")
-                        //이미지 저장 하는 코드를 짜야합니다.
+                        //티켓 저장 하는 코드를 짜야합니다.
+                        print("티켓 저장 동작")
                     }, label: {
                         ZStack {
                             RoundedRectangle(cornerRadius: 20)
-                                .fill(Color(red: 153/255, green: 153/255, blue: 153/255))
+                                .fill(Color.customGrey)
                             Text("티켓 저장")
-                                .font(.custom("Apple SD Gothic Neo Heavy",size:17,relativeTo: .title))
+                                .font(.custom("Apple SD Gothic Neo SemiBold",size:17,relativeTo: .title))
                                 .foregroundColor(Color.white)
                                 .padding()
                         }
                     })
-                    .frame(width: screenSize.width*0.42, height: screenSize.width*0.07)
+                    .frame(width: 165, height: 56)
+                    
                     Button(action: {
-                        print("이동 할꺼랍쇼")
+                        // 랜덤한 새로운 티켓을 다시 보여주는 코드를 짜야 합니다.
+                        print("새 티켓 뽑기 동작")
                     }, label: {
-                        //이미지 저장 하는 코드를 짜야합니다.
                         ZStack {
                             RoundedRectangle(cornerRadius: 20)
-                                .fill(Color(red: 255/255, green: 102/255, blue: 102/255))
+                                .fill(Color.customPink)
                             Text("새 티켓 뽑기")
-                                .font(.custom("Apple SD Gothic Neo Heavy",size:17,relativeTo: .title))
+                                .font(.custom("Apple SD Gothic Neo SemiBold",size:17,relativeTo: .title))
                                 .foregroundColor(Color.white)
                                 .padding()
                         }
                     })
-                    .frame(width: screenSize.width*0.42, height: screenSize.width*0.07)
-                            
+                    .frame(width: 165, height: 56)
                 }
-                .padding(.top, 24)
+                .padding()
             }
         }
-        . padding(.top, -1)
+        .navigationBarHidden(true)
+        .navigationTitle("Muse Ticket")
     }
 }
 

--- a/Muse/Muse/Main/TicketMachineView.swift
+++ b/Muse/Muse/Main/TicketMachineView.swift
@@ -1,0 +1,49 @@
+//
+//  TicketMachineView.swift
+//  Muse
+//
+//  Created by Admin on 2022/06/14.
+//
+
+import SwiftUI
+
+struct TicketMachineView: View {
+    var body: some View {
+        ZStack {
+            Image("machine")
+                .resizable()
+                .scaledToFit()
+                .frame(width: .infinity)
+            
+            VStack(spacing:40){
+                Text("뮤즈풀한 음악을 위해\n티켓을 뽑아보세요.")
+                    .font(.custom("Apple SD Gothic Neo SemiBold",size:20,relativeTo: .title))
+                    .foregroundColor(Color(red: 142/255, green: 142/255, blue: 147/255))
+                //RGB를 할때는 255로 나눠야 합니다!!
+                    .multilineTextAlignment(.center)
+                Text(
+                """
+                '\(Text("새 티켓 뽑기").underline())'를 터치해
+                랜덤으로 음악 티켓을 받을 수 있어요.
+                
+                '\(Text("티켓 저장").underline())'을 터치해
+                마음에 드는 음악과 코멘트를 모아보세요.
+                
+                '\(Text("내 라이브러리").underline())'에서
+                나의 음악 티켓을 작성할 수 있어요.
+                """)
+                .font(.custom("Apple SD Gothic Neo", size: 16, relativeTo: .title))
+                .foregroundColor(Color(red: 153/255, green: 153/255, blue: 153/255))
+                .multilineTextAlignment(.center)
+            }
+        }
+        .frame(width: .infinity, height: .infinity)
+        .padding(.horizontal)
+    }
+}
+
+struct TicketMachineView_Previews: PreviewProvider {
+    static var previews: some View {
+        TicketMachineView()
+    }
+}

--- a/Muse/Muse/Main/TicketMachineView.swift
+++ b/Muse/Muse/Main/TicketMachineView.swift
@@ -13,7 +13,6 @@ struct TicketMachineView: View {
             Image("machine")
                 .resizable()
                 .scaledToFit()
-                .frame(width: .infinity)
             
             VStack(spacing:40){
                 Text("뮤즈풀한 음악을 위해\n티켓을 뽑아보세요.")
@@ -37,7 +36,6 @@ struct TicketMachineView: View {
                 .multilineTextAlignment(.center)
             }
         }
-        .frame(width: .infinity, height: .infinity)
         .padding(.horizontal)
     }
 }

--- a/Muse/Muse/MakeTicket/MakeTicketView.swift
+++ b/Muse/Muse/MakeTicket/MakeTicketView.swift
@@ -14,13 +14,18 @@ struct MakeTicketView: View {
     var body: some View {
         ZStack {
             Color.bgGrey.ignoresSafeArea()
-            VStack {
-                Text("나만의 음악 티켓을 만들어 보세요.")
-                    .font(.title2.bold())
-                    .padding(.bottom)
+            VStack(spacing: 0) {
+//                Text("나만의 음악 티켓을 만들어 보세요.")
+//                    .font(.title2.bold())
+//                    .padding(.bottom)
                 ZStack {
                     Image("machine")
+                        .resizable()
+                        .scaledToFit()
                     Image("ticket")
+                        .resizable()
+                        .scaledToFit()
+                        .padding(.all, 32)
                     VStack {
                         Text("Song")
                             .font(.subheadline)
@@ -78,9 +83,11 @@ struct MakeTicketView: View {
                         .shadow(color: Color(red: 237/255, green: 237/255, blue: 237/255), radius: 2, x: 0, y: 2)
                         Spacer()
                     }
+                    .padding(.top, 5)
                     .frame(width: 286, height: 451)
                 }
-                
+                .padding(.top, 27)
+                .padding(.horizontal)
                 
                 Button(action: {
                     print("작성 완료다잉")
@@ -98,8 +105,11 @@ struct MakeTicketView: View {
                     }
                     .frame(width: 350, height: 56)
                 })
+                .padding()
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("티켓 제작")
     }
 }
 

--- a/Muse/Muse/MuseApp.swift
+++ b/Muse/Muse/MuseApp.swift
@@ -29,16 +29,13 @@ struct MuseApp: App {
     
     var body: some Scene {
         WindowGroup {
-            NavigationView {
-                switch sessionService.state {
-                    case .loggedIn:
-                        ContentView()
-                            .environmentObject(sessionService)
-                    case .loggedOut:
-                        LoginView()
-                    }
-                
-            }
+            switch sessionService.state {
+                case .loggedIn:
+                    ContentView()
+                        .environmentObject(sessionService)
+                case .loggedOut:
+                    LoginView()
+                }
         }
     }
 }

--- a/Muse/Muse/MyPage/MyPageView.swift
+++ b/Muse/Muse/MyPage/MyPageView.swift
@@ -32,43 +32,40 @@ struct MyPageView: View {
     @State private var selectedSide: LibraryType = .myTicket
     
     var body: some View {
-        NavigationView {
-            VStack(spacing: 0) {
-                // Header
-                HStack {
-                    Text("내 라이브러리")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                    Spacer()
-                    NavigationLink(destination: MakeTicketView()) {
-                        Image(systemName: "square.and.pencil")
-                            .font(.title)
-                    }
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("내 라이브러리")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                Spacer()
+                Button(action: {
+                    service.logout()
+                }) {
+                    Image(systemName: "rectangle.portrait.and.arrow.right")
+                        .font(.title)
                 }
-                .padding(.top)
-                .padding(.bottom, 10)
-                .padding(.horizontal)
-                // Picker
-                Picker("Choose a Side", selection: $selectedSide) {
-                    ForEach(LibraryType.allCases, id: \.self) {
-                        Text($0.rawValue)
-                    }
+                NavigationLink(destination: MakeTicketView()) {
+                    Image(systemName: "square.and.pencil")
+                        .font(.title)
                 }
-                .pickerStyle(SegmentedPickerStyle())
-                .padding()
-                
-                ChosenView(selectedSide: selectedSide)
             }
-            .navigationBarHidden(true)
-            .navigationTitle("내 라이브러리")
-          
-            AuthButton(title: "LogOut",
-                       background: .blue,
-                       foreground: .white,
-                       border: .clear) {
-                service.logout()
+            .padding(.top)
+            .padding(.bottom, 10)
+            .padding(.horizontal)
+            // Picker
+            Picker("Choose a Side", selection: $selectedSide) {
+                ForEach(LibraryType.allCases, id: \.self) {
+                    Text($0.rawValue)
+                }
             }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding()
+            
+            ChosenView(selectedSide: selectedSide)
         }
+        .navigationBarHidden(true)
+        .navigationTitle("내 라이브러리")
     }
 }
 

--- a/Muse/Muse/MyPage/MyPageView.swift
+++ b/Muse/Muse/MyPage/MyPageView.swift
@@ -66,6 +66,7 @@ struct MyPageView: View {
         }
         .navigationBarHidden(true)
         .navigationTitle("내 라이브러리")
+        .background(Color.bgGrey.edgesIgnoringSafeArea(.all))
     }
 }
 

--- a/Muse/Muse/MyPage/TicketListView.swift
+++ b/Muse/Muse/MyPage/TicketListView.swift
@@ -53,7 +53,7 @@ struct TicketListView: View {
                     .frame(width: 350, height: 100, alignment: .top)
                     .background(Color.white)
                     .cornerRadius(15)
-                    .shadow(color: .gray.opacity(0.5), radius: 5)
+                    .shadow(color: .gray.opacity(0.5), radius: 3)
                 }
             }
             .padding(.top, 20)


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
각자 작업한 View를 합치면서 화면 연결이 매끄럽게 되는지 확인 후 수정하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- NavigationView 정리
  - TabView 마다 NavigationView를 줘서 해당 페이지 내에서 NavigationLink로 전환될 때 탭뷰가 사라지지 않도록 수정
  - Museapp에서 NavigationView 삭제 후 LoginView에 NavigationView 따로 추가
- MyPageView
  - 내 라이브러리 페이지에서 Logout 버튼 개선 및 위치 수정
  - 내 라이브러리 페이지 카드 리스트 그림자 값 낮춰서 수정
- MainView
  - 탭뷰에 페이지가 가려지던 문제 수정
  - 안내 문구에서 '티켓저장', '새 티켓뽑기' '음악티켓'문구 -> '티켓 저장', '새 티켓 뽑기', '음악 티켓'으로 변경 (띄어쓰기 수정)
  - 하단부 버튼 글씨체 SemiBold 적용
  - Header 및 버튼 부분 패딩값 재조정
  - hi-fi에 맞게 하단부 버튼 사이즈 수정
  - Ticket Machine 부분 코드 분할해서 수정
- MakeTicketView
  - 탭뷰에 페이지가 가려지던 문제 수정
  - Navigation 상단탭으로 내 라이브러리 화면으로 돌아갈 수 있도록 수정
  - 상단탭으로 인해 티켓머신 사이즈가 달라지는 문제 수정
    - header의 "나만의 티켓을 만들어보세요." 문구 제거 후 navigation title로 대체
    - 상단 padding 값을 이용해서 MainView의 티켓머신과 크기가 같아지도록 사이즈 조절

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 뷰가 정상이 아니에요..ㅠㅠ MyPageView 빼고 왜 다 밀리죠..? ;;;
- MakeTicketView 개선 논의사항
  - 탭뷰를 가져지말고 상단 문구를 가져갈 것인가?
  - 탭뷰를 가져가고 상단문구 제거 후 네비게이션 타이틀을 활용할 것인가?
  - 네비게이션 뒤로가기 탭을 사용하지 않고 버튼 도입을 할 것 인가? (<- 방금 생각해냈는데 이게 가장 괜찮을 듯)