### PR TITLE
feat: 티켓뷰 사이즈값 조정 & 최초 화면에서 버튼 클릭 시 부터 티켓이 보이도록 구현 & 티켓 뽑기 시 적용한 Anim…

### DIFF
--- a/Muse/Muse/Main/MainView.swift
+++ b/Muse/Muse/Main/MainView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct MainView: View {
-    
+    @State var offset: CGFloat = 0.0
+    @State var flag: Bool = false
     let screenSize: CGSize = UIScreen.main.bounds.size
     
     var body: some View {
@@ -19,7 +20,7 @@ struct MainView: View {
                     .font(.custom("Courier New", size: 34, relativeTo: .title)) //relativeTo : 모든 기기마다 title이 갖는 값을 기준으로 34를 변환 시킨다.
                     .padding()
                 
-                TicketMachineView()
+                TicketMachineView(flag: $flag, offset: $offset)
     
                 HStack(alignment: .center, spacing: 20) {
                     Button(action: {
@@ -43,6 +44,10 @@ struct MainView: View {
                     Button(action: {
                         // 랜덤한 새로운 티켓을 다시 보여주는 코드를 짜야 합니다.
                         print("새 티켓 뽑기 동작")
+                        self.flag = true
+                        withAnimation {
+                            offset += 500
+                        }
                     }, label: {
                         ZStack {
                             RoundedRectangle(cornerRadius: 20)

--- a/Muse/Muse/Main/TicketMachineView.swift
+++ b/Muse/Muse/Main/TicketMachineView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct TicketMachineView: View {
+    @Binding var flag: Bool
+    @Binding var offset: CGFloat
+    
     var body: some View {
         ZStack {
             Image("machine")
@@ -35,6 +38,9 @@ struct TicketMachineView: View {
                 .foregroundColor(Color(red: 153/255, green: 153/255, blue: 153/255))
                 .multilineTextAlignment(.center)
             }
+            if flag {
+                TicketView(offset: $offset)
+            }
         }
         .padding(.horizontal)
     }
@@ -42,6 +48,6 @@ struct TicketMachineView: View {
 
 struct TicketMachineView_Previews: PreviewProvider {
     static var previews: some View {
-        TicketMachineView()
+        TicketMachineView(flag: .constant(true), offset: .constant(0.0))
     }
 }

--- a/Muse/Muse/Main/TicketView.swift
+++ b/Muse/Muse/Main/TicketView.swift
@@ -7,80 +7,74 @@
 
 import SwiftUI
 
-struct Ticket: View {
+struct TicketView: View {
     
-    @State private var offset: CGFloat = 0.0
+    @Binding var offset: CGFloat
     
     var body: some View {
-      VStack{
-          ZStack{
-              Image("machine")
-              
-        ZStack{
-                Image("ticket")
-            HStack{
+        VStack {
+            HStack(spacing: 20) {
                 Image("Album")
                     .resizable()
+                    .scaledToFit()
                     .frame(width: 66, height: 66)
-                    .offset(x:40,y:-180)
-            VStack(alignment: .leading){
-                Text("Dreams Like Me")
-                    .font(.headline)
-                    .offset(x:50,y:-180)
-                Text("Black Skirt")
-                    .offset(x:50,y:-170)
-                Divider()
-                    .background(Color.black)
-                    .frame(width: 250)
-                    .offset(x:-40,y:-150)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Dreams Like Me")
+                        .font(.headline)
+                        .padding(.vertical, 5)
+                        .lineLimit(1)
+                    Text("Black Skirt")
+                        .padding(.vertical, 5)
+                        .lineLimit(1)
                 }
+                Spacer()
             }
-
+            .padding(.top)
+            .padding(.bottom, 10)
+            .frame(width: 240)
+            
+            Divider()
+                .background(Color.black)
+                .frame(width: 240)
+            
             ScrollView{
                 Text("안녕하세요 제 이름은 검정치마........... 안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........안녕하세요 제 이름은 검정치마...........")
             }
-                    .frame(width: 260, height: 200)
-
+            .frame(width: 240, height: 190)
+            .padding(.vertical)
+            
+            Spacer()
+            
             Link(destination: URL(string: "https://music.apple.com/kr/album/dream-like-me/1626442550?i=1626442551/")!) {
                 ZStack{
                     Rectangle()
-                            .frame(width: 243, height: 60)
-                            .opacity(0)
-                Image("Play")
-                .resizable()
-                .frame(width: 32, height: 32)
-                .background()
-                .clipShape(Circle())
-                .foregroundColor(.black)
+                        .frame(width: 243, height: 60)
+                        .opacity(0)
+                    Image("Play")
+                        .resizable()
+                        .frame(width: 32, height: 32)
+                        .background()
+                        .clipShape(Circle())
+                        .foregroundColor(.black)
                 }
             }
-            .offset(x:0, y:186.5)
-            
-    }
+            .padding(.bottom, 21)
+        }
+        .frame(width: 280, height: 460)
+        .background(
+            Image("ticket")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 300, height: 480)
+        )
         .offset(y: -500)
         .animation(Animation.easeInOut(duration: 1.5), value: offset)
-        .offset(y: offset)
-         
-              Rectangle()
-                  .frame(width: 300, height: 200)
-                  .offset(y:-350)
-                  .foregroundColor(.white)
-              
-              Image("machine2")
-                  .offset(x:0, y:-327)
-          }
-          Button("눌러") {
-              withAnimation {
-              offset += 500
-                  }
-              }
-}
-        
+        .offset(y: offset)        
     }
     
 }
-struct Ticket_Previews: PreviewProvider {
+struct TicketView_Previews: PreviewProvider {
     static var previews: some View {
-        Ticket()
+        TicketView(offset: .constant(0.0))
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
Willow가 만든 티켓뷰 적용시키기 위해~

## Key Changes 🔥 (주요 구현/변경 사항)
- 티켓뷰 offset으로 위치 하드코딩 한 것 패딩값 조절 및 스택을 활용해서 페이지 수정
- 메인뷰에서 '새 티켓 뽑기' 클릭 시 초기화면에서 티켓이 생성되도록 구현 (초기화면에서는 티켓이 여전히 없는 상태가 유지되도록 구현)
- 티켓이 생성될 때 Willow가 구현한 Animation이 적용되도록 구현

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
화이팅!