### PR TITLE
AuthTextField와 AuthButton 수정

### DIFF
--- a/Muse/Muse/Auth/Login/LoginView.swift
+++ b/Muse/Muse/Auth/Login/LoginView.swift
@@ -24,7 +24,6 @@ struct LoginView: View {
                 .frame(width: 166, height: 51, alignment: .center)
                 .padding()
                 .padding(.top, -30)
-                .padding(.bottom, -5)
             
             
             Text("Our Music Universe,")
@@ -42,10 +41,12 @@ struct LoginView: View {
                           placeholder: "이메일을 입력해주세요",
                           keyboardType: .emailAddress,
                           sfSymbol: "envelope")
+            .padding(.bottom, -5)
             
             PwdTextFeild(password: $viewModel.credentials.password,
                          placeholder: "비밀번호를 입력해주세요",
                          sfSymbol: "lock")
+            .padding(.bottom, 10)
             
             AuthButton(title: "로그인",
                        background: .customPink,
@@ -53,6 +54,7 @@ struct LoginView: View {
                        border: .white) {
                 viewModel.login()
             }
+                       .padding(.bottom, -10)
             
             HStack{
                 // 기존의 회원가입 버튼을 text로 변경
@@ -94,7 +96,7 @@ struct LoginView: View {
 }
 
 struct LoginView_Previews: PreviewProvider {
-    static var previews: some View {        
+    static var previews: some View {
         LoginView()
     }
 }

--- a/Muse/Muse/Auth/Resister/ResisterView.swift
+++ b/Muse/Muse/Auth/Resister/ResisterView.swift
@@ -32,26 +32,28 @@ struct RegisterView: View {
                 .font(.system(size: 15, weight: .regular))
                 .foregroundColor(Color.black)
                 .frame(width: 246, height: 44, alignment: .leading)
-                .padding(.bottom, -30)
+                .padding(.bottom, -22)
                 .padding(.top, 30)
             
             AuthTextField(text: $viewModel.newUser.email,
                           placeholder: "omu@naver.com",
                           keyboardType: .emailAddress,
                           sfSymbol: "envelope")
+            .padding(.top, -15)
             
             Text("비밀번호")
                 .font(.system(size: 15, weight: .regular))
                 .foregroundColor(Color.black)
                 .frame(width: 246, height: 44, alignment: .leading)
                 .padding(.bottom, -30)
-                .padding(.top, -20)
+                .padding(.top, -30)
             
             PwdTextFeild(password: $viewModel.newUser.password,
                          placeholder: "6자리 이상 입력해주세요",
                          sfSymbol: "lock")
+            .padding(.top, -23)
             
-            VStack(spacing:15){
+            VStack(spacing: 10){
                 
                 AuthButton(title: "가입하기",
                            background: .customPink,
@@ -79,7 +81,6 @@ struct RegisterView: View {
                             .foregroundColor(Color.gray)
                     }
                 }
-                
                 
             }
         }

--- a/Muse/Muse/Base/AuthButton.swift
+++ b/Muse/Muse/Base/AuthButton.swift
@@ -41,7 +41,6 @@ struct AuthButton: View {
                 .stroke(border, lineWidth: 2)
                 .frame(width: 246, height: 44, alignment: .center)
         }
-        .padding(.top, -15)
     }
 }
 

--- a/Muse/Muse/Base/AuthTextField.swift
+++ b/Muse/Muse/Base/AuthTextField.swift
@@ -31,7 +31,6 @@ struct AuthTextField: View {
                 .frame(width: 246, height: 44, alignment: .center)
                 .foregroundColor(Color.customPink)
         }
-        .padding(.bottom, -5)
     }
 }
 
@@ -57,7 +56,6 @@ struct PwdTextFeild: View {
                 .frame(width: 246, height: 44, alignment: .center)
                 .foregroundColor(Color.customPink)                
         }
-        .padding(.bottom, 20)
     }
 }
 


### PR DESCRIPTION
LoginView와 RegisterView의 버튼들 위치를 다시 조정했습니다.

## Motivation 🥳 (코드를 추가/변경하게 된 이유)

AuthTextField와 AuthButton 가독성을 높이려고..?

## Key Changes 🔥 (주요 구현/변경 사항)

- AuthTextField와 AuthButton (Base) 패딩 제거
- 버튼 위치 조절은 실행되는 뷰에서만 하도록
- 디자인 수정

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

내일 금요일이다 꺄울 🔥