### PR TITLE
Ayden modify design2

### DIFF
--- a/Muse/Muse/Auth/Login/LoginView.swift
+++ b/Muse/Muse/Auth/Login/LoginView.swift
@@ -75,11 +75,14 @@ struct LoginView: View {
                     .sheet(isPresented: $showRegistration) {
                         RegisterView()
                     }
-            }.frame(width: 270, height: 20, alignment: .trailing)
+            }
+            .frame(width: 270, height: 20, alignment: .trailing)
+            .padding(.top, 5)
             
         }
         .padding(.horizontal, 15)
-        .navigationTitle("Login")
+//        .navigationTitle("Login")
+        .navigationBarHidden(true)
         
         //            .alert(isPresented: $viewModel.hasError,
         //                   content: {

--- a/Muse/Muse/Auth/Resister/ResisterView.swift
+++ b/Muse/Muse/Auth/Resister/ResisterView.swift
@@ -23,7 +23,7 @@ struct RegisterView: View {
                 .frame(width: 107, height: 33, alignment: .center)
                 .padding(.bottom, -10)
             
-            Text("회원가입")
+            Text("회원 가입")
                 .frame(width: 348, height: 41, alignment: .center)
                 .font(.system(size: 34, weight: .bold))
                 
@@ -31,7 +31,7 @@ struct RegisterView: View {
             Text("이메일")
                 .font(.system(size: 15, weight: .regular))
                 .foregroundColor(Color.black)
-                .frame(width: 246, height: 44, alignment: .leading)
+                .frame(width: 286, height: 44, alignment: .leading)
                 .padding(.bottom, -22)
                 .padding(.top, 30)
             
@@ -44,7 +44,7 @@ struct RegisterView: View {
             Text("비밀번호")
                 .font(.system(size: 15, weight: .regular))
                 .foregroundColor(Color.black)
-                .frame(width: 246, height: 44, alignment: .leading)
+                .frame(width: 286, height: 44, alignment: .leading)
                 .padding(.bottom, -30)
                 .padding(.top, -30)
             
@@ -69,15 +69,17 @@ struct RegisterView: View {
                 } label: {
                     HStack{
                         Text("괜찮아요, 다음에 할게요")
-                            .frame(width: 246, height: 44, alignment: .center)
-                            .font(.system(size: 13, weight: .regular))
+                            .frame(width: 286, height: 44, alignment: .center)
+//                            .font(.system(size: 13, weight: .regular))
+                            .font(.body)
                             .foregroundColor(Color.gray)
                             .padding(.leading, 20)
                     }
                     .overlay{
-                        RoundedRectangle(cornerRadius: 100)
+//                        RoundedRectangle(cornerRadius: 100)
+                        Capsule()
                             .stroke()
-                            .frame(width: 246, height: 44, alignment: .center)
+                            .frame(width: 286, height: 44, alignment: .center)
                             .foregroundColor(Color.gray)
                     }
                 }

--- a/Muse/Muse/Main/MainView.swift
+++ b/Muse/Muse/Main/MainView.swift
@@ -31,10 +31,11 @@ struct MainView: View {
                         ZStack {
                             Capsule()
                                 .fill(Color.customGrey)
-                                .frame(width: 160, height: 46)
+                                .frame(width: 160, height: 54)
                             HStack(spacing: 5) {
                                 Image(systemName: "square.and.arrow.down")
-                                    .padding(.trailing, 7)
+                                    .padding(.trailing, 3)
+                                    .offset(y: -2)
                                 Text("티켓 저장")
                             }
                             .font(.custom("Apple SD Gothic Neo SemiBold",size:17,relativeTo: .title))
@@ -88,11 +89,11 @@ struct MainView: View {
                         ZStack {
                             Capsule()
                                 .fill(Color.customPink)
-                                .frame(width: 160, height: 46)
+                                .frame(width: 160, height: 54)
                             HStack(spacing: 5) {
                                 Image(systemName: "arrow.triangle.2.circlepath")
-                                    .padding(.trailing, 7)
-                                Text("티켓 뽑기")
+                                    .padding(.trailing, 3)
+                                Text("새 티켓 뽑기")
                             }
                             .font(.custom("Apple SD Gothic Neo SemiBold",size:17,relativeTo: .title))
                             .foregroundColor(Color.white)

--- a/Muse/Muse/Main/TicketMachineView.swift
+++ b/Muse/Muse/Main/TicketMachineView.swift
@@ -13,6 +13,7 @@ struct TicketMachineView: View {
             Image("machine")
                 .resizable()
                 .scaledToFit()
+                
             
             VStack(spacing:40){
                 Text("뮤즈풀한 음악을 위해\n티켓을 뽑아보세요.")

--- a/Muse/Muse/Main/TicketView.swift
+++ b/Muse/Muse/Main/TicketView.swift
@@ -30,14 +30,16 @@ struct Ticket: View {
                             Text(randomSong.trackName )
                                 .font(.headline)
                                 .frame(width: 190, alignment: .leading)
-                                .offset(x:50,y:-180)
+                                .offset(x:50,y:-175)
                                 
                             Text(randomSong.artistName )
                                 .font(.subheadline)
                                 .frame(width: 180, alignment: .leading)
                                 .offset(x:50,y:-170)
+                                .foregroundColor(.gray)
                             Divider()
-                                .background(Color.black)
+//                                .background(Color.black)
+                                .background(.gray)
                                 .frame(width: 250)
                                 .offset(x:-40,y:-150)
 
@@ -106,9 +108,5 @@ struct Ticket: View {
 
 
 //
-//struct Ticket_Previews: PreviewProvider {
-//    static var previews: some View {
-//        Ticket()
-//    }
-//}
+//s`1qaza`
 //

--- a/Muse/Muse/MakeTicket/MakeTicketView.swift
+++ b/Muse/Muse/MakeTicket/MakeTicketView.swift
@@ -81,13 +81,14 @@ struct MakeTicketView: View {
                                     .frame(height:30)
                                 HStack {
                                     Image(systemName: "magnifyingglass")
-                                        .foregroundColor(.customGrey)
-                                    Text("제목, 가수를 입력해 보세요")
+//                                        .foregroundColor(.customGrey)
+                                    Text("제목, 가수를 입력해주세요")
                                         .font(.subheadline)
-                                        .multilineTextAlignment(.center)
-                                        .foregroundColor(.customGrey)
-                                    
+//                                        .multilineTextAlignment(.center)
+//                                        .foregroundColor(.customGrey)
                                 }
+                                .foregroundColor(.customGrey)
+                                .frame(width: 230, alignment: .leading)
                             }
                             .padding()
                             
@@ -99,7 +100,7 @@ struct MakeTicketView: View {
                         
                         HStack(){
                             ArtworkView(image: viewModel.artwork)
-                                .padding(.trailing)
+                                .padding(.trailing, 5)
                             VStack(alignment: .leading) {
                                 Text(viewModel.trackName)
                                 Text(viewModel.artistName)
@@ -109,9 +110,11 @@ struct MakeTicketView: View {
                             }
                             Spacer()
                         }
-                        .padding()
+                        .frame(width: 240)
+                        .padding(.top)
                         
-                        
+                        Divider().padding()
+                            .foregroundColor(.customGrey)
                         
                         Text("Comment")
                             .font(.subheadline)
@@ -177,11 +180,13 @@ struct MakeTicketView: View {
                     ZStack {
                         // 버튼 활성화 조건문 구현
                         if (isbuttonActivated == false){
-                            RoundedRectangle(cornerRadius: 20)
+//                            RoundedRectangle(cornerRadius: 20)
+                            Capsule()
                                 .foregroundColor(Color.gray)
                         }
                         else {
-                            RoundedRectangle(cornerRadius: 20)
+//                            RoundedRectangle(cornerRadius: 20)
+                            Capsule()
                                 .foregroundColor(Color.customPink)
                         }
                         

--- a/Muse/Muse/MusicSeach/MusicSearchView.swift
+++ b/Muse/Muse/MusicSeach/MusicSearchView.swift
@@ -16,6 +16,7 @@ struct MusicSearchView: View {
         //        NavigationView {
         VStack {
             SearchBar(searchTerm: $songListViewModel.searchTerm)
+                .padding(.horizontal)
             if songListViewModel.songs.isEmpty {
                 EmptyStateView()
             } else {
@@ -82,7 +83,7 @@ struct ArtworkView: View {
             }
         }
         .frame(width: 50, height: 50)
-        .shadow(radius: 5)
+//        .shadow(radius: 5)
         .padding(.trailing, 5)
     }
 }
@@ -92,17 +93,17 @@ struct EmptyStateView: View {
         VStack {
             Spacer()
             Image(systemName: "music.note.list")
-                .font(.system(size: 100))
+                .font(.system(size: 80))
                 .padding(.bottom)
                 .foregroundColor(Color.customPink)
             
-            Text("노래를 검색해주세요")
-                .font(.title)
+            Text("소개하고 싶은 음악을 \n검색해주세요")
+                .font(.title3)
                 .foregroundColor(Color.customPink)
             Spacer()
         }
         .padding()
-        .foregroundColor(Color(.systemIndigo))
+        .foregroundColor(.customPink)
     }
 }
 
@@ -116,7 +117,7 @@ struct SearchBar: UIViewRepresentable {
         let searchBar = UISearchBar(frame: .zero)
         searchBar.delegate = context.coordinator
         searchBar.searchBarStyle = .minimal
-        searchBar.placeholder = "곡, 가수, 앨범 명 검색"
+        searchBar.placeholder = "곡, 가수, 앨범명 등"
         // 한글로 변경?
         // "Type a song, artist, or album name..."
         return searchBar
@@ -143,8 +144,8 @@ struct SearchBar: UIViewRepresentable {
     }
 }
 
-//struct MusicSearchView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MusicSearchView(songListViewModel: SongListViewModel(), ticketWritingViewModel: TicketWritingViewModel())
-//    }
-//}
+struct MusicSearchView_Previews: PreviewProvider {
+    static var previews: some View {
+        MusicSearchView(songListViewModel: SongListViewModel(), ticketWritingViewModel: TicketWritingViewModel())
+    }
+}

--- a/Muse/Muse/MyPage/MyPageView.swift
+++ b/Muse/Muse/MyPage/MyPageView.swift
@@ -44,7 +44,7 @@ struct MyPageView: View {
                     service.logout()
                 }) {
                     Image(systemName: "rectangle.portrait.and.arrow.right")
-                        .font(.title)
+                        .font(.title2.bold())
                 }
 
                 NavigationLink(destination: MakeTicketView(isShowMakeTicketView: $isShowMakeTicketView), isActive: self.$isShowMakeTicketView) {

--- a/Muse/Muse/MyPage/TicketListView.swift
+++ b/Muse/Muse/MyPage/TicketListView.swift
@@ -28,15 +28,18 @@ struct TicketListView: View {
                                 // 곡 제목 - 가수 VStack
                                 VStack(alignment: .leading, spacing: 0) {
                                     Text(ticketList)
-                                        .font(.title2)
+                                        .font(.title3)
                                         .fontWeight(.bold)
                                         .multilineTextAlignment(.leading)
                                         .lineLimit(1)
+                                        .padding(.top, 7)
                                     Text("이소라 \(number)")
                                         .font(.callout)
                                         .multilineTextAlignment(.leading)
                                         .lineLimit(1)
+//                                        .padding(.top, 7)
                                         .padding(.top, 3)
+                                        .foregroundColor(.gray)
                                 }
                                 Spacer()
                                 // 조건문으로 받아오는 데이터 타입에 따라(저장한 티켓에서는) 아래 내용 표시 X
@@ -50,10 +53,11 @@ struct TicketListView: View {
                             .foregroundColor(.black)
                         }
                     }
-                    .frame(width: 350, height: 100, alignment: .top)
+//                    .frame(width: 350, height: 100, alignment: .top)
+                    .frame(width: 350, height: 120, alignment: .top)
                     .background(Color.white)
                     .cornerRadius(15)
-                    .shadow(color: .gray.opacity(0.5), radius: 3)
+                    .shadow(color: .gray.opacity(0.5), radius: 2)
                 }
             }
             .padding(.top, 20)


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)



## Key Changes 🔥 (주요 구현/변경 사항)

- Asset의 LogoImage, Pink Color 수정된 색깔로 넣음

- LoginView
    - 오뮤에 오신 걸 환영합니다 Text 주석 처리 -> 한 Text에 합침

- AuthTextField, PwdTestField
    - font(system) -> font(.subheadline)
    - .keyboardType(.emailAddress)
    - Rectangle -> Capsule로 변경
    - Size 246 -> 286으로 변경

- TicketMachineView
    - Text의 lineSpacing(5)를 추가
    - Font(.title3), .callout으로 변경
    - .foregroudColor(.customGrey)로 변경

- MainView
    - Capsule frame 46 -> 54
    - 티켓 뽑기 -> 새 티켓 뽑기 Text 변경
    - 버튼의 텍스트 padding(.trailing)을 7 -> 3으로 변경
    - 티켓 저장 버튼의 아이콘과 텍스트 가운데 맞춤. .offset 추가.

- TicketView
    - 노래 제목과 아티스트 이름 간격 위해 trackName.offset을 175로 변경
    - Divider 컬러를 gray로 변경

- MusicSearchView
    - 노래를 검색해주세요 Text font title -> title2, Image size 100 -> 80
    - SearchBar에 padding(.horizontal) 추가
    - ArtworkView의 shadow 삭제
    - “소개하고 싶은~”로 Text 변경
    - EmptyStateView의 indigo 컬러 -> customPink로 변경

- TicketListVIew
    - 곡 제목 title -> title 3으로 변경, padding(.top, 7) 추가
    - 가수 이름 padding 7 -> 3으로 변경, gray 컬러로 변경
    - 카드 frame height 100 -> 120으로 변경
    - Shadow radius 3 -> 2로 변경

- MakeTicketView
    - Search Bar 텍스트 왼쪽 정렬 위해 frame 추가하고 .leading함
    - Divider 추가
    - Artwork trailing 기존 -> 5로 변경, 다른 오브젝트들과 왼쪽 라인 맞추기 위해 frame, padding(.top, .horizontal) 코드 추가
    - 버튼 프레임 RoundedRectangle -> Capsule로 변경




- RegisterView
    - Frame size 246 -> 286으로 변경
    - “다음에 할게요” Text size 13 -> .body로 변경, Rectangle -> Capsule로 변경

- LoginView
    - navigationTitle 주석 처리 -> navigationBarHidden(true) 코드 추가



## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
